### PR TITLE
Older nokogiri compatibility

### DIFF
--- a/lib/transbank/webpay/document.rb
+++ b/lib/transbank/webpay/document.rb
@@ -42,7 +42,7 @@ module Transbank
       end
 
       def signed_xml
-        envelope.prepend_child(XML_HEADER)
+        envelope.children.first.add_previous_sibling(XML_HEADER)
         unsigned_xml = unsigned_document.to_s
 
         signer = Signer.new(unsigned_xml)

--- a/lib/transbank/webpay/version.rb
+++ b/lib/transbank/webpay/version.rb
@@ -1,5 +1,5 @@
 module Transbank
   module Webpay
-    VERSION = '0.2.2'.freeze
+    VERSION = '0.2.3'.freeze
   end
 end


### PR DESCRIPTION
I'am working in a old project that uses Nokogiri 1.5.11 and due a compatibility things i can't upgrade from this version. The problem was that the method `prepend_child` was added to Nokogiri on [1.6.2](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#162--2014-05-12), So, i use `add_previous_sibling` that is available from [1.4.2](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#142--20100522).
